### PR TITLE
[CI] Fix typo on RTL verification workflows

### DIFF
--- a/.github/workflows/rtl_verification.yml
+++ b/.github/workflows/rtl_verification.yml
@@ -40,8 +40,8 @@ jobs:
         id: git-diff-rtl
         run: |
           git fetch
-          git diff origin/main HEAD --name-status -- ':**/*.v' ':.github/**' ':Makefile' ':**/.py'
-          if git diff origin/main HEAD --name-status --exit-code -- ':**/*.v' ':.github/**' ':Makefile' ':**/.py'; then
+          git diff origin/main HEAD --name-status -- ':**/*.v' ':.github/**' ':Makefile' ':**/*.py'
+          if git diff origin/main HEAD --name-status --exit-code -- ':**/*.v' ':.github/**' ':Makefile' ':**/*.py'; then
             echo "::set-output name=source_modified::false"
           else
             echo "Detect changes in RTL. Require compilation check"


### PR DESCRIPTION
> ### Motivate of the pull request
> - [ ] To address an existing issue. If so, please provide a link to the issue: <issue id>
> - [x] Breaking new feature. If so, please describe details in the description part.

> ### Describe the technical details
> #### What is currently done? (Provide issue link if applicable)
> <!-- Please provide a list of limitations if not specified in any issue -->
> <!-- Below is a template, uncomment upon your needs -->
Currently, the project has the following limitations:
- The detect_changes steps cannot capture changes in cocotb testbenches. As a results, RTL verification workflow is not triggered when there are changes in cocotb python scripts.
>
> #### What does this pull request change?
> <!-- Please provide a list of highlights of your changes. -->
> <!-- Below is a template, uncomment upon your needs -->
This PR improves in the following aspects:
- [x] Corrected the typo in workflow so that the RTL verification workflow can be triggered as expected

> ### Which part of the code base require a change
> <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
> - [ ] RTL
> - [ ] Gate-level netlists
> - [ ] Design Verification
> - [ ] Physical Design
> - [ ] Timing characterization
> - [ ] Documentation
> - [ ] Regression tests
> - [x] Continous Integration (CI) scripts

> ### Impact of the pull request

> - [ ] Require a change on Quality of Results (QoR)
> - [ ] Break back-compatibility. If so, please list who may be influenced.
