### PR TITLE
Fixed Asynchronus Reset De-asssert Issue in Counter Tests

### DIFF
--- a/simple_registers/counters/counterdown16_1clk_negedge_async_resetp/test_counterdown16_1clk_negedge_async_resetp.py
+++ b/simple_registers/counters/counterdown16_1clk_negedge_async_resetp/test_counterdown16_1clk_negedge_async_resetp.py
@@ -34,6 +34,7 @@ async def test_counterdown16_1clk_negedge_async_resetp(dut):
   await ClockCycles(dut.clock0, 2)
   
   await FallingEdge(dut.clock0)
+  await Timer(1, units="ns")
   dut.reset.value = deassert_rst
   
   await RisingEdge(dut.clock0)
@@ -49,6 +50,7 @@ async def test_counterdown16_1clk_negedge_async_resetp(dut):
   dut._log.info("Reset Test1:: expected_count is %d", expected_count)
   assert dut.count.value == expected_count, "count does not match expected value!"
   await FallingEdge(dut.clock0)
+  await Timer(1, units="ns")
   dut.reset.value = deassert_rst
   await RisingEdge(dut.clock0)
   

--- a/simple_registers/counters/counterdown16_1clk_posedge_async_resetn/test_counterdown16_1clk_posedge_async_resetn.py
+++ b/simple_registers/counters/counterdown16_1clk_posedge_async_resetn/test_counterdown16_1clk_posedge_async_resetn.py
@@ -34,6 +34,7 @@ async def test_counterdown16_1clk_posedge_async_resetn(dut):
   await ClockCycles(dut.clock0, 2)
   
   await RisingEdge(dut.clock0)
+  await Timer(1, units="ns")
   dut.reset.value = deassert_rst
   
   await FallingEdge(dut.clock0)
@@ -49,6 +50,7 @@ async def test_counterdown16_1clk_posedge_async_resetn(dut):
   dut._log.info("Reset Test1:: expected_count is %d", expected_count)
   assert dut.count.value == expected_count, "count does not match expected value!"
   await RisingEdge(dut.clock0)
+  await Timer(1, units="ns")
   dut.reset.value = deassert_rst
   await FallingEdge(dut.clock0)
   

--- a/simple_registers/counters/counterdown16_1clk_posedge_async_resetp/test_counterdown16_1clk_posedge_async_resetp.py
+++ b/simple_registers/counters/counterdown16_1clk_posedge_async_resetp/test_counterdown16_1clk_posedge_async_resetp.py
@@ -34,6 +34,7 @@ async def test_counterdown16_1clk_posedge_async_resetp(dut):
   await ClockCycles(dut.clock0, 2)
   
   await RisingEdge(dut.clock0)
+  await Timer(1, units="ns")
   dut.reset.value = deassert_rst
   
   await FallingEdge(dut.clock0)
@@ -49,6 +50,7 @@ async def test_counterdown16_1clk_posedge_async_resetp(dut):
   dut._log.info("Reset Test1:: expected_count is %d", expected_count)
   assert dut.count.value == expected_count, "count does not match expected value!"
   await RisingEdge(dut.clock0)
+  await Timer(1, units="ns")
   dut.reset.value = deassert_rst
   await FallingEdge(dut.clock0)
   

--- a/simple_registers/counters/counterup16_1clk_posedge_async_resetn/test_counterup16_1clk_posedge_async_resetn.py
+++ b/simple_registers/counters/counterup16_1clk_posedge_async_resetn/test_counterup16_1clk_posedge_async_resetn.py
@@ -34,6 +34,7 @@ async def test_counterup16_1clk_posedge_async_resetn(dut):
   await ClockCycles(dut.clock0, 2)
   
   await RisingEdge(dut.clock0)
+  await Timer(1, units="ns")
   dut.reset.value = deassert_rst
   
   await FallingEdge(dut.clock0)
@@ -49,6 +50,7 @@ async def test_counterup16_1clk_posedge_async_resetn(dut):
   dut._log.info("Reset Test1:: expected_count is %d", expected_count)
   assert dut.count.value == expected_count, "count does not match expected value!"
   await RisingEdge(dut.clock0)
+  await Timer(1, units="ns")
   dut.reset.value = deassert_rst
   await FallingEdge(dut.clock0)
   

--- a/simple_registers/counters/counterup16_1clk_posedge_async_resetp/test_counterup16_1clk_posedge_async_resetp.py
+++ b/simple_registers/counters/counterup16_1clk_posedge_async_resetp/test_counterup16_1clk_posedge_async_resetp.py
@@ -34,6 +34,7 @@ async def test_counterup16_1clk_posedge_async_resetp(dut):
   await ClockCycles(dut.clock0, 2)
   
   await RisingEdge(dut.clock0)
+  await Timer(1, units="ns")
   dut.reset.value = deassert_rst
   
   await FallingEdge(dut.clock0)
@@ -49,6 +50,7 @@ async def test_counterup16_1clk_posedge_async_resetp(dut):
   dut._log.info("Reset Test1:: expected_count is %d", expected_count)
   assert dut.count.value == expected_count, "count does not match expected value!"
   await RisingEdge(dut.clock0)
+  await Timer(1, units="ns")
   dut.reset.value = deassert_rst
   await FallingEdge(dut.clock0)
   


### PR DESCRIPTION
> ### Motivate of the pull request
> - [x] To address an existing issue. If so, please provide a link to the issue: <issue id>
> - [ ] Breaking new feature. If so, please describe details in the description part.

> ### Describe the technical details
Asynchronus reset de-assertion should not be applied on/near the active clock-edge. Previously reset de-assertion performed o the active clock-edge causing the reset loss issue. This pr addresses the issue.
> #### What does this pull request change?
> <!-- Please provide a list of highlights of your changes. -->
> <!-- Below is a template, uncomment upon your needs -->
> <!-- This PR improves in the following aspects: -->
> <!-- - [ ] details about the technical highlight -->
> <!-- - [ ] <more technical highlights -->

> ### Which part of the code base require a change
> <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
> - [ ] RTL
> - [ ] Gate-level netlists
> - [ ] Design Verification
> - [ ] Physical Design
> - [ ] Timing characterization
> - [ ] Documentation
> - [ ] Regression tests
> - [ ] Continous Integration (CI) scripts

> ### Impact of the pull request

> - [ ] Require a change on Quality of Results (QoR)
> - [ ] Break back-compatibility. If so, please list who may be influenced.
